### PR TITLE
fix: unnecessary scrolling caused by floating-point precision issue

### DIFF
--- a/Sources/Turbocharger/Sources/View/MarqueeText.swift
+++ b/Sources/Turbocharger/Sources/View/MarqueeText.swift
@@ -97,7 +97,11 @@ private struct MarqueeTextBody: View {
                 ),
                 size: sizeThatFits
             )
-            if sizeThatFits.width <= frame.size.width {
+            let displayScale = ctx.environment.displayScale
+            let fittedWidth = (sizeThatFits.width * displayScale).rounded() / displayScale
+            let availableWidth = (frame.size.width * displayScale).rounded() / displayScale
+            let epsilon = 1 / displayScale
+            if fittedWidth <= availableWidth + epsilon {
                 ctx.draw(resolvedText, in: rect)
             } else {
                 let timestamp = keyframe * 40 * speed
@@ -106,7 +110,7 @@ private struct MarqueeTextBody: View {
                     .truncatingRemainder(
                         dividingBy: max(frame.size.width, sizeThatFits.width + spacing) + min(delayOffset, sizeThatFits.width)
                     ) - delayOffset
-                dx = (dx * ctx.environment.displayScale).rounded() / ctx.environment.displayScale
+                dx = (dx * displayScale).rounded() / displayScale
 
                 rect.origin.x -= dx
                 rect.origin.x = min(frame.origin.x, rect.origin.x)


### PR DESCRIPTION
### Summary
Fix unnecessary scrolling in MarqueeText caused by floating-point precision errors when comparing text width and container width.

### Details
In some edge cases, values that should be equal differ slightly due to floating-point rounding:

```
frame.size.width = 189.66666666666663
sizeThatFits.width = 189.66666666666666
```

This causes the condition `sizeThatFits.width <= frame.size.width` to fail and incorrectly triggers scrolling even though the text visually fits.

### Fix
Align both widths to the display scale and add a small tolerance (1 / displayScale) before comparison.

### Result
Prevents false-positive scrolling when the text actually fits within the available width.